### PR TITLE
Switch to Nebius Qwen models

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,8 +122,8 @@ For full functionality including real-time trading, you'll need to set up the fo
   - Set `ALPACA_USE_PAPER=True` for paper trading (recommended for testing)
   - Set `ALPACA_USE_PAPER=False` for live trading with real money
 
-- **OpenAI API Key** (Required for LLM agents):
-  - Sign up at [OpenAI Platform](https://platform.openai.com/api-keys)
+- **Nebius API Key** (Required for LLM agents):
+  - Sign up at [Nebius Console](https://console.nebius.ai/)
 
 #### Financial Data APIs
 - **Finnhub API Key** (Required for stock news and data):
@@ -222,7 +222,7 @@ The web interface offers comprehensive trading and analysis capabilities:
 
 ### Implementation Details
 
-Built with LangGraph for flexibility and modularity. The enhanced version integrates with multiple financial APIs and supports both paper and live trading through Alpaca. We recommend using `gpt-4o-mini` for testing to minimize API costs, as the framework makes numerous API calls across all 5 agents.
+Built with LangGraph for flexibility and modularity. The enhanced version integrates with multiple financial APIs and supports both paper and live trading through Alpaca. We recommend using `qwen-3-32b` for testing to minimize API costs, as the framework makes numerous API calls across all 5 agents.
 
 ### Python Usage
 
@@ -252,8 +252,8 @@ from tradingagents.default_config import DEFAULT_CONFIG
 
 # Create custom config for enhanced features
 config = DEFAULT_CONFIG.copy()
-config["deep_think_llm"] = "gpt-4o-mini"  # Cost-effective for testing
-config["quick_think_llm"] = "gpt-4o-mini"
+config["deep_think_llm"] = "qwen-3-235b"  # Default deep thinking model
+config["quick_think_llm"] = "qwen-3-32b"
 config["max_debate_rounds"] = 2  # Increase debate rounds
 config["online_tools"] = True  # Use real-time data
 config["enable_margin_trading"] = True  # Allow short selling

--- a/cli/utils.py
+++ b/cli/utils.py
@@ -127,11 +127,7 @@ def select_shallow_thinking_agent() -> str:
 
     # Define shallow thinking llm engine options with their corresponding model names
     SHALLOW_AGENT_OPTIONS = [
-        ("GPT-4.1 - Flagship GPT model for complex tasks", "gpt-4.1"),
-        ("GPT-4o-mini - Fast and efficient for quick tasks", "gpt-4o-mini"),
-        ("GPT-4.1-nano - Ultra-lightweight model for basic operations", "gpt-4.1-nano"),
-        ("GPT-4.1-mini - Compact model with good performance", "gpt-4.1-mini"),
-        ("GPT-4o - Standard model with solid capabilities", "gpt-4o"),
+        ("Qwen 3 32B - Fast and efficient for quick tasks", "qwen-3-32b"),
     ]
 
     choice = questionary.select(
@@ -164,14 +160,7 @@ def select_deep_thinking_agent() -> str:
 
     # Define deep thinking llm engine options with their corresponding model names
     DEEP_AGENT_OPTIONS = [
-        ("GPT-4.1 - Flagship GPT model for complex tasks", "gpt-4.1"),
-        ("GPT-4.1-nano - Ultra-lightweight model for basic operations", "gpt-4.1-nano"),
-        ("GPT-4.1-mini - Compact model with good performance", "gpt-4.1-mini"),
-        ("GPT-4o - Standard model with solid capabilities", "gpt-4o"),
-        ("o4-mini - Specialized reasoning model (compact)", "o4-mini"),
-        ("o3-mini - Advanced reasoning model (lightweight)", "o3-mini"),
-        ("o3 - Full advanced reasoning model", "o3"),
-        ("o1 - Premier reasoning and problem-solving model", "o1"),
+        ("Qwen 3 235B - Advanced reasoning model", "qwen-3-235b"),
     ]
 
     choice = questionary.select(

--- a/env.sample
+++ b/env.sample
@@ -12,9 +12,11 @@ ALPACA_SECRET_KEY=your_alpaca_secret_key_here
 # Set to True for paper trading, False for live trading
 ALPACA_USE_PAPER=True
 
-# OpenAI API Key - Required for LLM functionality
-# Get your key from https://platform.openai.com/api-keys
-OPENAI_API_KEY=your_openai_api_key_here
+# Nebius API Key - Required for LLM functionality
+# Sign up at https://console.nebius.ai/ to obtain your key
+NEBIUS_API_KEY=your_nebius_api_key_here
+# Base URL for the Nebius OpenAI-compatible endpoint
+NEBIUS_BASE_URL=https://api.nebius.ai/v1
 
 # Finnhub API Key - Required for financial news and data
 # Get your key from https://finnhub.io/register

--- a/main.py
+++ b/main.py
@@ -4,8 +4,8 @@ from tradingagents.default_config import DEFAULT_CONFIG
 
 # Create a custom config
 config = DEFAULT_CONFIG.copy()
-config["deep_think_llm"] = "gpt-4.1-mini"  # Use a different model
-config["quick_think_llm"] = "gpt-4.1-mini"  # Use a different model
+config["deep_think_llm"] = "qwen-3-235b"  # Use a different model
+config["quick_think_llm"] = "qwen-3-32b"  # Use a different model
 config["max_debate_rounds"] = 1  # Increase debate rounds
 config["online_tools"] = True  # Increase debate rounds
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 typing-extensions
 langchain-openai
+openai
 langchain-experimental
 pandas
 praw

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,7 @@ setup(
     install_requires=[
         "langchain>=0.1.0",
         "langchain-openai>=0.0.2",
+        "openai>=1.0.0",
         "langchain-experimental>=0.0.40",
         "langgraph>=0.0.20",
         "numpy>=1.24.0",

--- a/tradingagents/agents/analysts/fundamentals_analyst.py
+++ b/tradingagents/agents/analysts/fundamentals_analyst.py
@@ -48,11 +48,11 @@ def create_fundamentals_analyst(llm, toolkit):
                     # print(f"[FUNDAMENTALS] Using online crypto tools: DeFiLlama + Events Calendar")
                 else:
                     tools = [
-                        toolkit.get_fundamentals_openai,
+                        toolkit.get_fundamentals_nebius,
                         toolkit.get_earnings_calendar,
                         toolkit.get_earnings_surprise_analysis,
                     ]
-                    # print(f"[FUNDAMENTALS] Using online stock tools: OpenAI Fundamentals + Earnings Analysis")
+                    # print(f"[FUNDAMENTALS] Using online stock tools: Nebius Fundamentals + Earnings Analysis")
             else:
                 tools = [
                     toolkit.get_finnhub_company_insider_sentiment,

--- a/tradingagents/agents/analysts/news_analyst.py
+++ b/tradingagents/agents/analysts/news_analyst.py
@@ -20,7 +20,7 @@ def create_news_analyst(llm, toolkit):
         is_crypto = "/" in ticker or "USD" in ticker.upper() or "USDT" in ticker.upper()
 
         if toolkit.config["online_tools"]:
-            tools = [toolkit.get_global_news_openai, toolkit.get_google_news]
+            tools = [toolkit.get_global_news_nebius, toolkit.get_google_news]
         else:
             if is_crypto:
                 tools = [

--- a/tradingagents/agents/analysts/social_media_analyst.py
+++ b/tradingagents/agents/analysts/social_media_analyst.py
@@ -20,7 +20,7 @@ def create_social_media_analyst(llm, toolkit):
 
         if toolkit.config["online_tools"]:
             tools = [
-                toolkit.get_stock_news_openai,
+                toolkit.get_stock_news_nebius,
             ]
         else:
             tools = [

--- a/tradingagents/agents/utils/agent_utils.py
+++ b/tradingagents/agents/utils/agent_utils.py
@@ -519,12 +519,12 @@ class Toolkit:
     @staticmethod
     @tool
     @timing_wrapper("SOCIAL")
-    def get_stock_news_openai(
+    def get_stock_news_nebius(
         ticker: Annotated[str, "the company's ticker"],
         curr_date: Annotated[str, "Current date in yyyy-mm-dd format"],
     ):
         """
-        Retrieve the latest news about a given stock by using OpenAI's news API.
+        Retrieve the latest news about a given stock by using Nebius's news API.
         Args:
             ticker (str): Ticker of a company. e.g. AAPL, TSM
             curr_date (str): Current date in yyyy-mm-dd format
@@ -532,37 +532,37 @@ class Toolkit:
             str: A formatted string containing the latest news about the company on the given date.
         """
 
-        openai_news_results = interface.get_stock_news_openai(ticker, curr_date)
+        nebius_news_results = interface.get_stock_news_nebius(ticker, curr_date)
 
-        return openai_news_results
+        return nebius_news_results
 
     @staticmethod
     @tool
     @timing_wrapper("NEWS")
-    def get_global_news_openai(
+    def get_global_news_nebius(
         curr_date: Annotated[str, "Current date in yyyy-mm-dd format"],
     ):
         """
-        Retrieve the latest macroeconomics news on a given date using OpenAI's macroeconomics news API.
+        Retrieve the latest macroeconomics news on a given date using Nebius's macroeconomics news API.
         Args:
             curr_date (str): Current date in yyyy-mm-dd format
         Returns:
             str: A formatted string containing the latest macroeconomic news on the given date.
         """
 
-        openai_news_results = interface.get_global_news_openai(curr_date)
+        nebius_news_results = interface.get_global_news_nebius(curr_date)
 
-        return openai_news_results
+        return nebius_news_results
 
     @staticmethod
     @tool
     @timing_wrapper("FUNDAMENTALS")
-    def get_fundamentals_openai(
+    def get_fundamentals_nebius(
         ticker: Annotated[str, "the company's ticker"],
         curr_date: Annotated[str, "Current date in yyyy-mm-dd format"],
     ):
         """
-        Retrieve the latest fundamental information about a given stock on a given date by using OpenAI's news API.
+        Retrieve the latest fundamental information about a given stock on a given date by using Nebius's news API.
         Args:
             ticker (str): Ticker of a company. e.g. AAPL, TSM
             curr_date (str): Current date in yyyy-mm-dd format
@@ -570,11 +570,11 @@ class Toolkit:
             str: A formatted string containing the latest fundamental information about the company on the given date.
         """
 
-        openai_fundamentals_results = interface.get_fundamentals_openai(
+        nebius_fundamentals_results = interface.get_fundamentals_nebius(
             ticker, curr_date
         )
 
-        return openai_fundamentals_results
+        return nebius_fundamentals_results
 
     @staticmethod
     @tool

--- a/tradingagents/agents/utils/memory.py
+++ b/tradingagents/agents/utils/memory.py
@@ -8,15 +8,16 @@ from tradingagents.dataflows.config import get_api_key
 class FinancialSituationMemory:
     def __init__(self, name):
         # Get API key from environment variables or config
-        api_key = get_api_key("openai_api_key", "OPENAI_API_KEY")
-        self.client = OpenAI(api_key=api_key)
+        api_key = get_api_key("nebius_api_key", "NEBIUS_API_KEY")
+        base_url = get_api_key("nebius_base_url", "NEBIUS_BASE_URL") or "https://api.nebius.ai/v1"
+        self.client = OpenAI(api_key=api_key, base_url=base_url)
         self.chroma_client = chromadb.Client(Settings(allow_reset=True))
         self.situation_collection = self.chroma_client.get_or_create_collection(name=name)
 
     def get_embedding(self, text):
-        """Get OpenAI embedding for a text"""
+        """Get Nebius embedding for a text"""
         response = self.client.embeddings.create(
-            model="text-embedding-ada-002", input=text
+            model="text-embedding-qwen", input=text
         )
         return response.data[0].embedding
 
@@ -44,7 +45,7 @@ class FinancialSituationMemory:
         )
 
     def get_memories(self, current_situation, n_matches=1):
-        """Find matching recommendations using OpenAI embeddings"""
+        """Find matching recommendations using Nebius embeddings"""
         query_embedding = self.get_embedding(current_situation)
 
         results = self.situation_collection.query(

--- a/tradingagents/dataflows/config.py
+++ b/tradingagents/dataflows/config.py
@@ -48,9 +48,9 @@ def get_api_key(key_name: str, env_var_name: str) -> str:
     return api_key
 
 
-def get_openai_api_key() -> str:
-    """Get OpenAI API key from environment variables or config."""
-    return get_api_key("openai_api_key", "OPENAI_API_KEY")
+def get_nebius_api_key() -> str:
+    """Get Nebius API key from environment variables or config."""
+    return get_api_key("nebius_api_key", "NEBIUS_API_KEY")
 
 
 def get_finnhub_api_key() -> str:

--- a/tradingagents/dataflows/interface.py
+++ b/tradingagents/dataflows/interface.py
@@ -533,18 +533,19 @@ def get_stockstats_indicator(
         return f"Error getting {indicator} for {symbol}: {str(e)}"
 
 
-def get_stock_news_openai(ticker, curr_date):
-    # Get API key from environment variables or config
-    api_key = get_api_key("openai_api_key", "OPENAI_API_KEY")
+def get_stock_news_nebius(ticker, curr_date):
+    # Get API key and base URL from environment variables or config
+    api_key = get_api_key("nebius_api_key", "NEBIUS_API_KEY")
+    base_url = get_api_key("nebius_base_url", "NEBIUS_BASE_URL") or "https://api.nebius.ai/v1"
     if not api_key:
-        return f"Error: OpenAI API key not found. Please set OPENAI_API_KEY environment variable."
-    
+        return f"Error: Nebius API key not found. Please set NEBIUS_API_KEY environment variable."
+
     try:
-        client = OpenAI(api_key=api_key)
-        
+        client = OpenAI(api_key=api_key, base_url=base_url)
+
         # Get the selected quick model from config
         config = get_config()
-        model = config.get("quick_think_llm", "gpt-4o-mini")  # fallback to default
+        model = config.get("quick_think_llm", "qwen-3-32b")  # fallback to default
         
         from datetime import datetime, timedelta
         start_date = (datetime.strptime(curr_date, "%Y-%m-%d") - timedelta(days=7)).strftime("%Y-%m-%d")
@@ -575,18 +576,19 @@ def get_stock_news_openai(ticker, curr_date):
         return f"Error fetching social media analysis for {ticker}: {str(e)}"
 
 
-def get_global_news_openai(curr_date):
-    # Get API key from environment variables or config
-    api_key = get_api_key("openai_api_key", "OPENAI_API_KEY")
+def get_global_news_nebius(curr_date):
+    # Get API key and base URL from environment variables or config
+    api_key = get_api_key("nebius_api_key", "NEBIUS_API_KEY")
+    base_url = get_api_key("nebius_base_url", "NEBIUS_BASE_URL") or "https://api.nebius.ai/v1"
     if not api_key:
-        return f"Error: OpenAI API key not found. Please set OPENAI_API_KEY environment variable."
-    
+        return f"Error: Nebius API key not found. Please set NEBIUS_API_KEY environment variable."
+
     try:
-        client = OpenAI(api_key=api_key)
-        
+        client = OpenAI(api_key=api_key, base_url=base_url)
+
         # Get the selected quick model from config
         config = get_config()
-        model = config.get("quick_think_llm", "gpt-4o-mini")  # fallback to default
+        model = config.get("quick_think_llm", "qwen-3-32b")  # fallback to default
         
         from datetime import datetime, timedelta
         start_date = (datetime.strptime(curr_date, "%Y-%m-%d") - timedelta(days=7)).strftime("%Y-%m-%d")
@@ -618,18 +620,19 @@ def get_global_news_openai(curr_date):
         return f"Error fetching global news analysis: {str(e)}"
 
 
-def get_fundamentals_openai(ticker, curr_date):
-    # Get API key from environment variables or config
-    api_key = get_api_key("openai_api_key", "OPENAI_API_KEY")
+def get_fundamentals_nebius(ticker, curr_date):
+    # Get API key and base URL from environment variables or config
+    api_key = get_api_key("nebius_api_key", "NEBIUS_API_KEY")
+    base_url = get_api_key("nebius_base_url", "NEBIUS_BASE_URL") or "https://api.nebius.ai/v1"
     if not api_key:
-        return f"Error: OpenAI API key not found. Please set OPENAI_API_KEY environment variable."
-    
+        return f"Error: Nebius API key not found. Please set NEBIUS_API_KEY environment variable."
+
     try:
-        client = OpenAI(api_key=api_key)
-        
+        client = OpenAI(api_key=api_key, base_url=base_url)
+
         # Get the selected quick model from config
         config = get_config()
-        model = config.get("quick_think_llm", "gpt-4o-mini")  # fallback to default
+        model = config.get("quick_think_llm", "qwen-3-32b")  # fallback to default
         
         from datetime import datetime, timedelta
         start_date = (datetime.strptime(curr_date, "%Y-%m-%d") - timedelta(days=30)).strftime("%Y-%m-%d")

--- a/tradingagents/default_config.py
+++ b/tradingagents/default_config.py
@@ -9,8 +9,8 @@ DEFAULT_CONFIG = {
         "dataflows/data_cache",
     ),
     # LLM settings
-    "deep_think_llm": "o3-mini",
-    "quick_think_llm": "gpt-4o-mini",
+    "deep_think_llm": "qwen-3-235b",
+    "quick_think_llm": "qwen-3-32b",
     # Debate and discussion settings
     "max_debate_rounds": 4,
     "max_risk_discuss_rounds": 3,
@@ -22,7 +22,8 @@ DEFAULT_CONFIG = {
     # Tool settings
     "online_tools": True,
     # API keys (these will be overridden by environment variables if present)
-    "openai_api_key": None,
+    "nebius_api_key": None,
+    "nebius_base_url": "https://api.nebius.ai/v1",
     "finnhub_api_key": None,
     "alpaca_api_key": None,
     "alpaca_secret_key": None,

--- a/tradingagents/graph/trading_graph.py
+++ b/tradingagents/graph/trading_graph.py
@@ -56,7 +56,8 @@ class TradingAgentsGraph:
         )
 
         # Get API key from environment variables or config
-        api_key = get_api_key("openai_api_key", "OPENAI_API_KEY")
+        api_key = get_api_key("nebius_api_key", "NEBIUS_API_KEY")
+        base_url = get_api_key("nebius_base_url", "NEBIUS_BASE_URL") or "https://api.nebius.ai/v1"
 
         # Initialize LLMs with appropriate parameters based on model type
         deep_think_model = self.config["deep_think_llm"]
@@ -74,14 +75,16 @@ class TradingAgentsGraph:
             quick_think_kwargs["temperature"] = 0.2
         
         self.deep_thinking_llm = ChatOpenAI(
-            model=deep_think_model, 
+            model=deep_think_model,
             openai_api_key=api_key,
+            base_url=base_url,
             **deep_think_kwargs
         )
         
         self.quick_thinking_llm = ChatOpenAI(
-            model=quick_think_model, 
+            model=quick_think_model,
             openai_api_key=api_key,
+            base_url=base_url,
             **quick_think_kwargs
         )
         
@@ -146,7 +149,7 @@ class TradingAgentsGraph:
             "social": ToolNode(
                 [
                     # online tools
-                    self.toolkit.get_stock_news_openai,
+                    self.toolkit.get_stock_news_nebius,
                     # offline tools
                     self.toolkit.get_reddit_stock_info,
                     # crypto
@@ -156,7 +159,7 @@ class TradingAgentsGraph:
             "news": ToolNode(
                 [
                     # online tools
-                    self.toolkit.get_global_news_openai,
+                    self.toolkit.get_global_news_nebius,
                     self.toolkit.get_google_news,
                     # offline tools
                     self.toolkit.get_finnhub_news,
@@ -168,7 +171,7 @@ class TradingAgentsGraph:
             "fundamentals": ToolNode(
                 [
                     # online tools
-                    self.toolkit.get_fundamentals_openai,
+                    self.toolkit.get_fundamentals_nebius,
                     self.toolkit.get_defillama_fundamentals,
                     # offline tools
                     self.toolkit.get_finnhub_company_insider_sentiment,

--- a/webui/assets/custom.css
+++ b/webui/assets/custom.css
@@ -360,7 +360,7 @@ body {
     box-shadow: 0 4px 12px rgba(239, 68, 68, 0.3);
 }
 
-/* Markdown Table Styling - ChatGPT-like appearance */
+/* Markdown Table Styling - LLM-like appearance */
 .dash-markdown table {
     width: 100%;
     border-collapse: collapse;

--- a/webui/components/config_panel.py
+++ b/webui/components/config_panel.py
@@ -160,32 +160,20 @@ def create_config_panel():
             dbc.Select(
                 id="quick-llm",
                 options=[
-                    {"label": "gpt-4.1", "value": "gpt-4.1"},
-                    {"label": "gpt-4.1-nano", "value": "gpt-4.1-nano"},
-                    {"label": "gpt-4.1-mini", "value": "gpt-4.1-mini"},
-                    {"label": "gpt-4o", "value": "gpt-4o"},
-                    {"label": "o4-mini", "value": "o4-mini"},
-                    {"label": "o3-mini", "value": "o3-mini"},
-                    {"label": "o3", "value": "o3"},
-                    {"label": "o1", "value": "o1"},
+                    {"label": "qwen-3-32b", "value": "qwen-3-32b"},
+                    {"label": "qwen-3-235b", "value": "qwen-3-235b"},
                 ],
-                value="gpt-4.1-nano",
+                value="qwen-3-32b",
                 className="mb-2"
             ),
             html.H5("LLM Deep Thinker Model:", className="mt-3"),
             dbc.Select(
                 id="deep-llm",
                 options=[
-                    {"label": "gpt-4.1", "value": "gpt-4.1"},
-                    {"label": "gpt-4.1-nano", "value": "gpt-4.1-nano"},
-                    {"label": "gpt-4.1-mini", "value": "gpt-4.1-mini"},
-                    {"label": "gpt-4o", "value": "gpt-4o"},
-                    {"label": "o4-mini", "value": "o4-mini"},
-                    {"label": "o3-mini", "value": "o3-mini"},
-                    {"label": "o3", "value": "o3"},
-                    {"label": "o1", "value": "o1"},
+                    {"label": "qwen-3-235b", "value": "qwen-3-235b"},
+                    {"label": "qwen-3-32b", "value": "qwen-3-32b"},
                 ],
-                value="gpt-4.1-nano",
+                value="qwen-3-235b",
                 className="mb-3"
             ),
             # Dynamic Start/Stop button


### PR DESCRIPTION
## Summary
- use Nebius Qwen models instead of OpenAI
- replace OpenAI-specific news and fundamentals functions with Nebius equivalents
- expose Qwen model selection in CLI and web UI

## Testing
- `pytest`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_688f6fce21f483338594552443e50e91